### PR TITLE
Corrigido chamada de evento duplicada.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.reratos</groupId>
     <artifactId>MobInventory</artifactId>
-    <version>0.4.0-alpha</version>
+    <version>0.4.1-alpha</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/me/reratos/mobinventory/events/PlayerListener.java
+++ b/src/main/java/me/reratos/mobinventory/events/PlayerListener.java
@@ -42,9 +42,17 @@ public class PlayerListener implements Listener {
         Player player = event.getPlayer();
         Entity entity = event.getRightClicked();
 
-        if(entity instanceof Player) {
+        EquipmentSlot hand = event.getHand();
+//        MainHand mainHand = event.getPlayer().getMainHand();
+
+        // Cancela o evento caso o evento não seja chamado com a mão principal
+        if(!hand.equals(EquipmentSlot.HAND)) {
             event.setCancelled(true);
             return;
+        }
+
+        if(entity instanceof Player) {
+            event.setCancelled(true);
         } else if(entity instanceof LivingEntity) {
 //            player.sendMessage("\n ====== PlayerInteractEntityEvent ======");
 //            player.sendMessage("Right Click in Entity (" + entity.getName() + ")");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,9 +1,9 @@
 name: MobInventory
-version: 0.4.0-alpha
+version: 0.4.1-alpha
 api-version: 1.13
 main: me.reratos.mobinventory.MobInventory
 author: Relry
 database: false
 website: todo
 description: >
-  Permite visualizar o inventário de um mob.
+  Allows you to view a mob's inventory.


### PR DESCRIPTION
Conforme documentação do spigot o evento PlayerInteractEntityEvent é chamado duas vezes, uma para cada mão, para alguns mobs ainda é chamado uma unica vez.
- Verificando se o evento foi lançado com a mão principal.